### PR TITLE
feat: Upgrade extension to Manifest V3

### DIFF
--- a/manifest/chrome.json
+++ b/manifest/chrome.json
@@ -4,32 +4,25 @@
 	"version": "__version__",
 	"description": "__MSG_description__",
 	"homepage_url": "http://team.firefoxcn.net",
-	"manifest_version": 2,
+	"manifest_version": 3,
 	"icons": {
 		"128": "images/128.png"
 	},
 	"permissions": [
 		"tabs",
 		"webNavigation",
-		"webRequest",
-		"webRequestBlocking",
 		"contextMenus",
 		"storage",
 		"downloads",
-		"*://*/*",
 		"clipboardWrite",
-		"unlimitedStorage"
+		"unlimitedStorage",
+		"declarativeNetRequest"
+	],
+	"host_permissions": [
+		"*://*/*"
 	],
 	"background": {
-		"scripts": [
-			"scripts/browser-polyfill.js",
-			"scripts/common.js",
-			"scripts/messaging.js",
-			"scripts/userstyle.js",
-			"scripts/storage.js",
-			"scripts/GhostText.js",
-			"scripts/background.js"
-		]
+		"service_worker": "scripts/service-worker.js"
 	},
 	"content_scripts": [
 		{
@@ -92,7 +85,7 @@
 			]
 		}
 	],
-	"browser_action": {
+	"action": {
 		"default_icon": {
 			"128": "images/128.png"
 		},

--- a/scripts/service-worker.js
+++ b/scripts/service-worker.js
@@ -1,0 +1,70 @@
+try {
+    importScripts(
+        './browser-polyfill.js',
+        './common.js',
+        './messaging.js',
+        './userstyle.js',
+        './storage.js',
+        './GhostText.js',
+        './background.js'
+    );
+} catch (e) {
+    console.error(e);
+}
+
+const userstylesRule = {
+    "id": 1,
+    "priority": 1,
+    "action": {
+        "type": "modifyHeaders",
+        "requestHeaders": [
+            { "header": "Referer", "operation": "set", "value": "https://userstyles.org/" }
+        ]
+    },
+    "condition": {
+        "urlFilter": "*://userstyles.org/*",
+        "resourceTypes": ["main_frame", "sub_frame", "stylesheet", "script", "image", "object", "xmlhttprequest", "other"]
+    }
+};
+
+const cspRule = {
+    "id": 2,
+    "priority": 1,
+    "action": {
+        "type": "modifyHeaders",
+        "responseHeaders": [
+            { "header": "Content-Security-Policy", "operation": "append", "value": "style-src 'unsafe-inline'" }
+        ]
+    },
+    "condition": {
+        "urlFilter": "*://*/*",
+        "resourceTypes": ["main_frame", "sub_frame"]
+    }
+};
+
+async function updateRules() {
+    const { 'modify-csp': modifyCsp } = await browser.storage.local.get('modify-csp');
+
+    const rules = [userstylesRule];
+    if (modifyCsp) {
+        rules.push(cspRule);
+    }
+
+    const oldRules = await chrome.declarativeNetRequest.getDynamicRules();
+    const oldRuleIds = oldRules.map(rule => rule.id);
+
+    await chrome.declarativeNetRequest.updateDynamicRules({
+        removeRuleIds: oldRuleIds,
+        addRules: rules
+    });
+}
+
+// Update rules when the extension starts
+updateRules();
+
+// Update rules when the preference changes
+browser.storage.onChanged.addListener((changes, area) => {
+    if (area === 'local' && changes['modify-csp']) {
+        updateRules();
+    }
+});


### PR DESCRIPTION
This commit upgrades the Chrome extension from Manifest V2 to Manifest V3 to comply with the latest Chrome extension standards.

The following changes were made:
- Updated `manifest.json` to version 3.
- Replaced the background page with a service worker.
- Replaced the blocking `webRequest` API with the `declarativeNetRequest` API for modifying headers.
- Refactored `localStorage` usage in the background script to use `chrome.storage.local`, which is compatible with service workers.
- Renamed `browser_action` to `action` in the manifest.
- Moved host permissions to the `host_permissions` field in the manifest.
